### PR TITLE
Stage 3: Azure fetcher reservation extension

### DIFF
--- a/PROJECT_TODO.md
+++ b/PROJECT_TODO.md
@@ -113,14 +113,14 @@
 
 ## Stage 3 — Azure Fetcher Reservation Extension
 
-- [ ] **Goal:** [scripts/fetch_azure.py](scripts/fetch_azure.py) currently captures `Consumption` rows; extend to also capture `Reservation` rows and merge them as commitments on the matching VM SKU.
+- [x] **Goal:** [scripts/fetch_azure.py](scripts/fetch_azure.py) currently captures `Consumption` rows; extend to also capture `Reservation` rows and merge them as commitments on the matching VM SKU.
 
 **Tasks**
-- [ ] In `fetch_azure.py`, when paging through the retail prices API for VM service, no longer filter out `type: 'Reservation'`. Instead, group by `armSkuName` + `armRegionName`.
-- [ ] Build a commitment from each Reservation row using `reservationTerm` (`1 Year` or `3 Years`) and the price as `effectiveHourlyUSD` (Azure already amortizes).
-- [ ] Set `payment: 'all-upfront'` for Reservation (Azure's retail API only exposes the upfront-equivalent hourly).
-- [ ] Add a `DevTestConsumption` filter (skip — that's not standard pricing).
-- [ ] Confirm China region rows still load (the existing static-data fallback is OK).
+- [x] In `fetch_azure.py`, when paging through the retail prices API for VM service, no longer filter out `type: 'Reservation'`. Instead, group by `armSkuName` + `armRegionName`.
+- [x] Build a commitment from each Reservation row using `reservationTerm` (`1 Year` or `3 Years`) and the price as `effectiveHourlyUSD` (Azure already amortizes).
+- [x] Set `payment: 'all-upfront'` for Reservation (Azure's retail API only exposes the upfront-equivalent hourly).
+- [x] Add a `DevTestConsumption` filter (skip — that's not standard pricing).
+- [x] Confirm China region rows still load (the existing static-data fallback is OK).
 
 **Verification**
 - `python scripts/fetch_azure.py` produces `data/providers/azure.raw.json`
@@ -128,8 +128,8 @@
 - `python scripts/utils/data_validator.py data/providers/azure.raw.json` passes
 
 **Definition of Done**
-- [ ] No regression: total VM count ≥ previous run
-- [ ] PR: `v3/stage-3-azure-reservations`
+- [x] No regression: total VM count ≥ previous run
+- [x] PR: `v3/stage-3-azure-reservations`
 
 ---
 

--- a/scripts/fetch_azure.py
+++ b/scripts/fetch_azure.py
@@ -1,18 +1,648 @@
 # scripts/fetch_azure.py
 """
-Fetch Azure VM pricing and specs.
-This is a placeholder script. Implement data fetching logic here.
+Fetch Azure VM pricing and specs using the Azure Retail Prices API.
+No authentication required — uses the public retail prices API.
+
+Stage 3 extensions:
+- Captures both Consumption and Reservation priceType rows.
+- Skips DevTestConsumption rows (non-standard pricing).
+- Groups by armSkuName + armRegionName (per-region) so Reservation rows
+  can be merged as commitments onto the matching Consumption VM entry.
+- Outputs data/providers/azure.raw.json in the v3 schema with commitments[].
 """
 
 import json
+import re
+import sys
+import os
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
 
-def fetch_azure_data():
-    # TODO: Implement actual fetching logic
-    data = []
-    # Example: data.append({"instanceType": "Standard_B1ls", "vCPU": 1, "memoryGiB": 0.5, "priceUSD": 0.005, ...})
-    return data
+import requests
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'utils'))
+from data_normalizer import normalize_commitments
+from azure_regions import get_country_from_azure_region, create_location_detail
+from azure_services import (
+    get_service_category,
+    get_service_type_from_category,
+    is_virtual_machine_service,
+    is_dedicated_host_service,
+    get_china_region_mapping,
+)
+
+# ---------------------------------------------------------------------------
+# Azure Retail Prices API
+# ---------------------------------------------------------------------------
+RETAIL_PRICES_URL = "https://prices.azure.com/api/retail/prices"
+API_VERSION = "2023-01-01-preview"
+
+# We only care about Virtual Machines for v3 (compute-only scope).
+# Database and other service fetchers are deferred to v3.1.
+VM_SERVICE_NAME = "Virtual Machines"
+
+# Reservation term strings as returned by the API
+TERM_MAP = {
+    "1 Year": "1yr",
+    "3 Years": "3yr",
+}
+
+# ---------------------------------------------------------------------------
+# ARM-architecture detection
+# ---------------------------------------------------------------------------
+_ARM_SKU_RE = re.compile(r'_p[1-9]\d*[bmsv]*', re.IGNORECASE)  # Dpsv5, Epsv6 etc.
+_ARM_KEYWORDS = ('ampere', 'arm', '_p')
+
+def detect_architecture(sku_name: str) -> str:
+    """Return 'arm64' for known ARM SKUs, else 'x86_64'."""
+    if not sku_name:
+        return 'x86_64'
+    s = sku_name.lower()
+    if 'dpds' in s or 'dpsv' in s or 'epsv' in s or 'dpls' in s or '_p' in s:
+        return 'arm64'
+    return 'x86_64'
+
+# ---------------------------------------------------------------------------
+# Family extraction
+# ---------------------------------------------------------------------------
+_FAMILY_RE = re.compile(r'^Standard_([A-Z]+)', re.IGNORECASE)
+
+def extract_family(sku_name: str) -> str:
+    """Extract normalised family id from Azure SKU name (e.g. 'Standard_D2s_v5' -> 'd')."""
+    if not sku_name:
+        return 'unknown'
+    m = _FAMILY_RE.match(sku_name)
+    if m:
+        return m.group(1).lower()
+    return sku_name.split('_')[0].lower() if '_' in sku_name else sku_name.lower()
+
+# ---------------------------------------------------------------------------
+# SKU spec lookup table (vCPU, memoryGiB)
+# ---------------------------------------------------------------------------
+# Comprehensive exact-match table; pattern fallback below if not found.
+EXACT_SKU_SPECS: Dict[str, Tuple[int, float]] = {
+    # A-series
+    'Standard_A0': (1, 0.768), 'Standard_A1': (1, 1.75), 'Standard_A2': (2, 3.5),
+    'Standard_A3': (4, 7), 'Standard_A4': (8, 14), 'Standard_A5': (2, 14),
+    'Standard_A6': (4, 28), 'Standard_A7': (8, 56),
+    # Av2
+    'Standard_A1_v2': (1, 2), 'Standard_A2_v2': (2, 4), 'Standard_A4_v2': (4, 8),
+    'Standard_A8_v2': (8, 16), 'Standard_A2m_v2': (2, 16), 'Standard_A4m_v2': (4, 32),
+    'Standard_A8m_v2': (8, 64),
+    # B-series (burstable)
+    'Standard_B1ls': (1, 0.5), 'Standard_B1s': (1, 1), 'Standard_B1ms': (1, 2),
+    'Standard_B2s': (2, 4), 'Standard_B2ms': (2, 8), 'Standard_B4ms': (4, 16),
+    'Standard_B8ms': (8, 32), 'Standard_B12ms': (12, 48), 'Standard_B16ms': (16, 64),
+    'Standard_B20ms': (20, 80), 'Standard_B32ms': (32, 128), 'Standard_B48ms': (48, 192),
+    'Standard_B64ms': (64, 256), 'Standard_B80ms': (80, 320),
+    # D-series v5
+    'Standard_D2s_v5': (2, 8), 'Standard_D4s_v5': (4, 16), 'Standard_D8s_v5': (8, 32),
+    'Standard_D16s_v5': (16, 64), 'Standard_D32s_v5': (32, 128),
+    'Standard_D48s_v5': (48, 192), 'Standard_D64s_v5': (64, 256),
+    'Standard_D96s_v5': (96, 384),
+    # D-series v4
+    'Standard_D2s_v4': (2, 8), 'Standard_D4s_v4': (4, 16), 'Standard_D8s_v4': (8, 32),
+    'Standard_D16s_v4': (16, 64), 'Standard_D32s_v4': (32, 128),
+    'Standard_D48s_v4': (48, 192), 'Standard_D64s_v4': (64, 256),
+    # D-series v3
+    'Standard_D2s_v3': (2, 8), 'Standard_D4s_v3': (4, 16), 'Standard_D8s_v3': (8, 32),
+    'Standard_D16s_v3': (16, 64), 'Standard_D32s_v3': (32, 128),
+    'Standard_D48s_v3': (48, 192), 'Standard_D64s_v3': (64, 256),
+    # E-series v5
+    'Standard_E2s_v5': (2, 16), 'Standard_E4s_v5': (4, 32), 'Standard_E8s_v5': (8, 64),
+    'Standard_E16s_v5': (16, 128), 'Standard_E20s_v5': (20, 160),
+    'Standard_E32s_v5': (32, 256), 'Standard_E48s_v5': (48, 384),
+    'Standard_E64s_v5': (64, 512), 'Standard_E96s_v5': (96, 672),
+    'Standard_E104is_v5': (104, 672),
+    # E-series v4
+    'Standard_E2s_v4': (2, 16), 'Standard_E4s_v4': (4, 32), 'Standard_E8s_v4': (8, 64),
+    'Standard_E16s_v4': (16, 128), 'Standard_E20s_v4': (20, 160),
+    'Standard_E32s_v4': (32, 256), 'Standard_E48s_v4': (48, 384),
+    'Standard_E64s_v4': (64, 512),
+    # F-series
+    'Standard_F1': (1, 2), 'Standard_F2': (2, 4), 'Standard_F4': (4, 8),
+    'Standard_F8': (8, 16), 'Standard_F16': (16, 32),
+    # Fsv2
+    'Standard_F2s_v2': (2, 4), 'Standard_F4s_v2': (4, 8), 'Standard_F8s_v2': (8, 16),
+    'Standard_F16s_v2': (16, 32), 'Standard_F32s_v2': (32, 64),
+    'Standard_F48s_v2': (48, 96), 'Standard_F64s_v2': (64, 128),
+    'Standard_F72s_v2': (72, 144),
+    # M-series
+    'Standard_M8ms': (8, 218.75), 'Standard_M16ms': (16, 437.5),
+    'Standard_M32ts': (32, 192), 'Standard_M32ls': (32, 256),
+    'Standard_M32ms': (32, 875), 'Standard_M64s': (64, 1024),
+    'Standard_M64ls': (64, 512), 'Standard_M64ms': (64, 1792),
+    'Standard_M128s': (128, 2048), 'Standard_M128ms': (128, 3892),
+    # NC-series (GPU)
+    'Standard_NC6': (6, 56), 'Standard_NC12': (12, 112), 'Standard_NC24': (24, 224),
+    'Standard_NC6s_v3': (6, 112), 'Standard_NC12s_v3': (12, 224),
+    'Standard_NC24s_v3': (24, 448),
+    # NV-series (GPU)
+    'Standard_NV6': (6, 56), 'Standard_NV12': (12, 112), 'Standard_NV24': (24, 224),
+    # L-series
+    'Standard_L4s': (4, 32), 'Standard_L8s': (8, 64), 'Standard_L16s': (16, 128),
+    'Standard_L32s': (32, 256), 'Standard_L8s_v2': (8, 64), 'Standard_L16s_v2': (16, 128),
+    'Standard_L32s_v2': (32, 256), 'Standard_L48s_v2': (48, 384),
+    'Standard_L64s_v2': (64, 512), 'Standard_L80s_v2': (80, 640),
+}
+
+# Pattern-based fallback (vCPU, memory ratio)
+_SKU_PATTERNS = [
+    (re.compile(r'^Standard_D(\d+)s?_v\d+$', re.I), lambda n: (n, n * 4)),
+    (re.compile(r'^Standard_E(\d+)i?s?_v\d+$', re.I), lambda n: (n, n * 8)),
+    (re.compile(r'^Standard_F(\d+)s?_v\d+$', re.I), lambda n: (n, n * 2)),
+    (re.compile(r'^Standard_M(\d+)m?s?$', re.I), lambda n: (n, n * 14)),
+    (re.compile(r'^Standard_NC(\d+)r?s?_v\d+$', re.I), lambda n: (n, n * 14)),
+    (re.compile(r'^Standard_H(\d+)r?s?$', re.I), lambda n: (n, n * 7)),
+    (re.compile(r'^Standard_D(\d+)$', re.I), lambda n: (n, n * 3.5)),
+    (re.compile(r'^Standard_E(\d+)$', re.I), lambda n: (n, n * 8)),
+    (re.compile(r'^Standard_F(\d+)$', re.I), lambda n: (n, n * 2)),
+]
+
+
+def parse_sku_specs(sku_name: str) -> Tuple[Optional[int], Optional[float]]:
+    """Return (vCPU, memoryGiB) for the given Azure SKU, or (None, None)."""
+    if not sku_name:
+        return None, None
+
+    if sku_name in EXACT_SKU_SPECS:
+        return EXACT_SKU_SPECS[sku_name]
+
+    for pattern, extractor in _SKU_PATTERNS:
+        m = pattern.match(sku_name)
+        if m:
+            n = int(m.group(1))
+            vcpu, mem = extractor(n)
+            return int(vcpu), float(mem)
+
+    # Last-resort: extract first number
+    m = re.search(r'[A-Z](\d+)', sku_name)
+    if m:
+        n = int(m.group(1))
+        s = sku_name.upper()
+        if 'E' in s:
+            return n, float(n * 8)
+        if 'F' in s:
+            return n, float(n * 2)
+        if 'M' in s:
+            return n, float(n * 14)
+        return n, float(n * 4)
+
+    return None, None
+
+
+# ---------------------------------------------------------------------------
+# China static fallback
+# ---------------------------------------------------------------------------
+
+def fetch_china_static() -> List[Dict[str, Any]]:
+    """
+    Azure China (21Vianet) uses a separate restricted API.
+    Return a small set of static representative instances so that
+    China region rows are present in the output.
+    """
+    print("Note: Azure China pricing requires 21Vianet API access. Using static fallback.")
+    china_regions = ['chinaeast', 'chinaeast2', 'chinanorth', 'chinanorth2', 'chinanorth3']
+    china_region_map = get_china_region_mapping()
+
+    sample_skus = [
+        {'sku': 'Standard_B2s', 'vcpu': 2, 'mem': 4, 'factor': 0.95},
+        {'sku': 'Standard_D2s_v5', 'vcpu': 2, 'mem': 8, 'factor': 0.92},
+        {'sku': 'Standard_D4s_v5', 'vcpu': 4, 'mem': 16, 'factor': 0.92},
+        {'sku': 'Standard_E4s_v5', 'vcpu': 4, 'mem': 32, 'factor': 0.90},
+    ]
+
+    instances = []
+    now = datetime.utcnow().isoformat()
+    for s in sample_skus:
+        hourly = round(0.05 * s['vcpu'] * s['factor'], 6)
+        loc_details = []
+        for r in china_regions:
+            country = china_region_map.get(r.lower(), 'China')
+            loc_details.append(create_location_detail(r, country))
+
+        instances.append({
+            'provider': 'azure',
+            'type': 'cloud-server',
+            'instanceType': s['sku'],
+            'vCPU': s['vcpu'],
+            'memoryGiB': float(s['mem']),
+            'priceUSD_hourly': hourly,
+            'priceUSD_monthly': round(hourly * 730.44, 4),
+            'architecture': detect_architecture(s['sku']),
+            'family': extract_family(s['sku']),
+            'commitments': [],
+            'regions': ['China'],
+            'locationDetails': loc_details,
+            'source': 'Azure China Static Data (21Vianet fallback)',
+            'lastUpdated': now,
+            'marketSegment': 'china',
+            'operatedBy': '21Vianet',
+            'raw': {
+                'note': 'Static pricing data — verify with 21Vianet for actual pricing.',
+                'serviceName': VM_SERVICE_NAME,
+                'armSkuName': s['sku'],
+                'marketSegment': 'china',
+            },
+        })
+
+    print(f"Added {len(instances)} China instances (static fallback).")
+    return instances
+
+
+# ---------------------------------------------------------------------------
+# Main fetcher
+# ---------------------------------------------------------------------------
+
+def _page_items(price_type_filter: str) -> List[Dict[str, Any]]:
+    """
+    Fetch all pages from the Azure Retail Prices API for Virtual Machines
+    with the given priceType filter, returning the combined list of items.
+    """
+    params = {
+        "$filter": (
+            f"serviceName eq '{VM_SERVICE_NAME}' and priceType eq '{price_type_filter}'"
+        ),
+        "api-version": API_VERSION,
+    }
+    items: List[Dict[str, Any]] = []
+    url: Optional[str] = RETAIL_PRICES_URL
+    page = 0
+
+    while url:
+        page += 1
+        try:
+            if page == 1:
+                resp = requests.get(url, params=params, timeout=60)
+            else:
+                resp = requests.get(url, timeout=60)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            print(f"  [page {page}] Request error: {exc}", flush=True)
+            break
+
+        body = resp.json()
+        batch = body.get('Items', []) if isinstance(body, dict) else body
+        items.extend(batch)
+        url = body.get('NextPageLink') if isinstance(body, dict) else None
+        if page % 5 == 0:
+            print(f"  ... fetched {len(items)} {price_type_filter} records so far "
+                  f"(page {page})", flush=True)
+
+    print(f"  Total {price_type_filter} records fetched: {len(items)}", flush=True)
+    return items
+
+
+def fetch_azure_data() -> List[Dict[str, Any]]:
+    """
+    Fetch Azure VM pricing (Consumption + Reservation) from the public
+    Retail Prices API and return a list of normalised instance dicts
+    in v3 schema format with commitments[].
+    """
+    now = datetime.utcnow().isoformat()
+    china_region_map = get_china_region_mapping()
+
+    # ------------------------------------------------------------------
+    # 1. Fetch Consumption rows (on-demand pricing)
+    # ------------------------------------------------------------------
+    print("Fetching Consumption (on-demand) rows…", flush=True)
+    consumption_items = _page_items('Consumption')
+
+    # ------------------------------------------------------------------
+    # 2. Fetch Reservation rows (1yr / 3yr committed pricing)
+    # ------------------------------------------------------------------
+    print("Fetching Reservation rows…", flush=True)
+    reservation_items = _page_items('Reservation')
+
+    # ------------------------------------------------------------------
+    # 3. Build consumption groups keyed by (armSkuName, armRegionName)
+    #
+    # Key choice: armSkuName + armRegionName gives us per-region per-SKU
+    # entries so that reservation rows (which also carry armRegionName)
+    # can be merged onto the correct base record.
+    # ------------------------------------------------------------------
+    # consumption_groups: key -> instance dict (will grow commitments[])
+    consumption_groups: Dict[Tuple[str, str], Dict[str, Any]] = {}
+
+    skipped_windows_sql = 0
+    skipped_devtest = 0
+    skipped_no_sku = 0
+    skipped_no_specs = 0
+
+    for item in consumption_items:
+        sku_name: str = item.get('armSkuName', '') or ''
+        region: str = item.get('armRegionName', '') or ''
+        service_name: str = item.get('serviceName', '')
+        meter_name: str = item.get('meterName', '') or ''
+        price_type: str = item.get('priceType', '')
+
+        # Only Virtual Machines service
+        if service_name != VM_SERVICE_NAME:
+            continue
+
+        # Skip DevTestConsumption — not standard pricing
+        if price_type == 'DevTestConsumption':
+            skipped_devtest += 1
+            continue
+
+        # Skip Windows and SQL variants (prefer Linux on-demand)
+        if 'Windows' in meter_name or 'SQL' in meter_name:
+            skipped_windows_sql += 1
+            continue
+
+        # Skip Spot and Low Priority pricing — those are not standard on-demand.
+        sku_display: str = item.get('skuName', '') or ''
+        if 'Spot' in sku_display or 'Low Priority' in sku_display:
+            continue
+
+        # Skip dedicated host (scope: compute VMs only)
+        if is_dedicated_host_service(service_name, meter_name):
+            continue
+
+        if not sku_name:
+            skipped_no_sku += 1
+            continue
+
+        vcpu, mem_gib = parse_sku_specs(sku_name)
+        if vcpu is None or mem_gib is None:
+            skipped_no_specs += 1
+            continue
+
+        # Determine region → country
+        if region.lower() in china_region_map:
+            country = china_region_map[region.lower()]
+        else:
+            country = get_country_from_azure_region(region)
+        loc_detail = create_location_detail(region, country)
+
+        hourly = float(item.get('unitPrice', 0) or 0)
+        monthly = round(hourly * 730.44, 4)
+
+        key = (sku_name, region)
+        if key not in consumption_groups:
+            consumption_groups[key] = {
+                'provider': 'azure',
+                'type': 'cloud-server',
+                'instanceType': sku_name,
+                'vCPU': vcpu,
+                'memoryGiB': float(mem_gib),
+                'priceUSD_hourly': hourly,
+                'priceUSD_monthly': monthly,
+                'architecture': detect_architecture(sku_name),
+                'family': extract_family(sku_name),
+                'commitments': [],
+                'regions': [country] if country else [],
+                'locationDetails': [loc_detail],
+                'source': 'Azure Retail Prices API',
+                'lastUpdated': now,
+                'marketSegment': 'global',
+                'operatedBy': 'Microsoft',
+                'raw': {
+                    'serviceName': service_name,
+                    'meterName': meter_name,
+                    'armSkuName': sku_name,
+                    'armRegionName': region,
+                    'location': item.get('location', ''),
+                    'currencyCode': item.get('currencyCode', 'USD'),
+                },
+            }
+        else:
+            # If same SKU+region appears again with a lower price, keep lower
+            existing = consumption_groups[key]
+            if hourly > 0 and (existing['priceUSD_hourly'] == 0 or hourly < existing['priceUSD_hourly']):
+                existing['priceUSD_hourly'] = hourly
+                existing['priceUSD_monthly'] = monthly
+
+    print(f"Consumption groups built: {len(consumption_groups)}", flush=True)
+    print(f"  Skipped — Windows/SQL: {skipped_windows_sql}, DevTest: {skipped_devtest}, "
+          f"no SKU: {skipped_no_sku}, no specs: {skipped_no_specs}", flush=True)
+
+    # ------------------------------------------------------------------
+    # 4. Merge Reservation rows as commitments
+    # ------------------------------------------------------------------
+    reservation_matched = 0
+    reservation_unmatched = 0
+    skipped_res_windows_sql = 0
+
+    for item in reservation_items:
+        sku_name: str = item.get('armSkuName', '') or ''
+        region: str = item.get('armRegionName', '') or ''
+        meter_name: str = item.get('meterName', '') or ''
+        reservation_term: str = item.get('reservationTerm', '') or ''
+
+        # Skip Windows/SQL reservations
+        if 'Windows' in meter_name or 'SQL' in meter_name:
+            skipped_res_windows_sql += 1
+            continue
+
+        if not sku_name or not region:
+            reservation_unmatched += 1
+            continue
+
+        term_key = TERM_MAP.get(reservation_term)
+        if term_key is None:
+            # Unknown term — skip
+            reservation_unmatched += 1
+            continue
+
+        key = (sku_name, region)
+        base = consumption_groups.get(key)
+        if base is None:
+            # No matching consumption entry; create a bare base so the
+            # reservation is still represented (on-demand price = 0).
+            vcpu, mem_gib = parse_sku_specs(sku_name)
+            if vcpu is None:
+                reservation_unmatched += 1
+                continue
+
+            if region.lower() in china_region_map:
+                country = china_region_map[region.lower()]
+            else:
+                country = get_country_from_azure_region(region)
+            loc_detail = create_location_detail(region, country)
+
+            base = {
+                'provider': 'azure',
+                'type': 'cloud-server',
+                'instanceType': sku_name,
+                'vCPU': int(vcpu),
+                'memoryGiB': float(mem_gib),
+                'priceUSD_hourly': 0.0,
+                'priceUSD_monthly': 0.0,
+                'architecture': detect_architecture(sku_name),
+                'family': extract_family(sku_name),
+                'commitments': [],
+                'regions': [country] if country else [],
+                'locationDetails': [loc_detail],
+                'source': 'Azure Retail Prices API (reservation-only)',
+                'lastUpdated': now,
+                'marketSegment': 'global',
+                'operatedBy': 'Microsoft',
+                'raw': {
+                    'serviceName': VM_SERVICE_NAME,
+                    'armSkuName': sku_name,
+                    'armRegionName': region,
+                },
+            }
+            consumption_groups[key] = base
+
+        # Azure Retail Prices API returns the *total* reservation cost for the
+        # term (despite unitOfMeasure saying "1 Hour").  We must amortise it.
+        # e.g. Standard_D2s_v5 1yr = $496 total → $496/8760 ≈ $0.0566/hr
+        term_hours = 8760 if term_key == '1yr' else 26280
+        total_cost = float(item.get('unitPrice', 0) or 0)
+        amortised_hourly = round(total_cost / term_hours, 8) if term_hours > 0 else 0.0
+
+        raw_commitment = {
+            'term': term_key,
+            'payment': 'all-upfront',  # Azure retail exposes upfront-equivalent amortised hourly
+            'product': 'reserved',
+            'priceUSD_hourly': amortised_hourly,
+            # upfront_usd omitted because effectiveHourlyUSD == amortised_hourly already
+        }
+        normalised = normalize_commitments([raw_commitment], base['priceUSD_hourly'])
+        if normalised:
+            # Avoid duplicate term entries
+            existing_terms = {(c['term'], c['payment']) for c in base['commitments']}
+            for nc in normalised:
+                if (nc['term'], nc['payment']) not in existing_terms:
+                    base['commitments'].append(nc)
+                    existing_terms.add((nc['term'], nc['payment']))
+            reservation_matched += 1
+        else:
+            reservation_unmatched += 1
+
+    print(f"Reservations merged: {reservation_matched} matched, "
+          f"{reservation_unmatched} unmatched/skipped, "
+          f"{skipped_res_windows_sql} Windows/SQL skipped.", flush=True)
+
+    # ------------------------------------------------------------------
+    # 5. Collapse per-region groups into per-SKU instances
+    #
+    # Following the AWS fetcher pattern (Stage 2): one record per SKU across
+    # all regions.  We use eastus as the canonical pricing reference region —
+    # it is the primary Azure region where most standard pricing is anchored.
+    # If eastus is absent for a SKU, fall back to the first encountered region.
+    #
+    # Commitments are kept from the canonical region only; duplicates (same
+    # term+payment) from other regions are discarded.  savingsVsOnDemandPct is
+    # computed against the canonical region's on-demand price so the validator
+    # cross-field check is always consistent.
+    # ------------------------------------------------------------------
+    CANONICAL_REGION = 'eastus'
+
+    # First pass: group per-SKU with a preference for the canonical region.
+    # We store all per-region data first, then select the canonical.
+    sku_region_map: Dict[str, Dict[str, Dict[str, Any]]] = {}
+    for (sku_name, region), inst in consumption_groups.items():
+        sku_region_map.setdefault(sku_name, {})[region] = inst
+
+    per_sku: Dict[str, Dict[str, Any]] = {}
+    for sku_name, region_data in sku_region_map.items():
+        # Pick canonical region
+        if CANONICAL_REGION in region_data:
+            canonical_inst = region_data[CANONICAL_REGION]
+        else:
+            canonical_inst = next(iter(region_data.values()))
+
+        canonical_od = canonical_inst['priceUSD_hourly']
+
+        # Build the merged per-SKU record from the canonical instance
+        agg = {
+            **canonical_inst,
+            'regions': [],
+            'locationDetails': [],
+            'commitments': list(canonical_inst.get('commitments', [])),
+            'regionPricing': {},
+        }
+
+        # Populate regions + regionPricing from all regions
+        seen_locs: set = set()
+        seen_countries: set = set()
+        for region, inst in region_data.items():
+            od = inst['priceUSD_hourly']
+            if od > 0:
+                agg['regionPricing'][region] = od
+            for country in inst.get('regions', []):
+                if country not in seen_countries:
+                    agg['regions'].append(country)
+                    seen_countries.add(country)
+            for ld in inst.get('locationDetails', []):
+                code = ld['code']
+                if code not in seen_locs:
+                    agg['locationDetails'].append(ld)
+                    seen_locs.add(code)
+
+        # Re-normalise commitments against canonical on-demand
+        normalised_commitments = []
+        seen_term_payment: set = set()
+        for c in agg['commitments']:
+            key = (c['term'], c['payment'])
+            if key in seen_term_payment:
+                continue
+            seen_term_payment.add(key)
+            effective = c.get('effectiveHourlyUSD', c.get('priceUSD_hourly', 0))
+            if canonical_od > 0:
+                savings = max(0.0, min(100.0,
+                    (1.0 - effective / canonical_od) * 100.0))
+            else:
+                savings = 0.0
+            normalised_commitments.append({
+                'term': c['term'],
+                'payment': c['payment'],
+                'product': c['product'],
+                'priceUSD_hourly': c['priceUSD_hourly'],
+                'effectiveHourlyUSD': round(effective, 8),
+                'savingsVsOnDemandPct': round(savings, 2),
+            })
+        agg['commitments'] = normalised_commitments
+
+        per_sku[sku_name] = agg
+
+    instances = list(per_sku.values())
+    print(f"Final unique SKU count (global): {len(instances)}", flush=True)
+
+    # ------------------------------------------------------------------
+    # 6. Basic validation: drop instances with no price and no specs
+    # ------------------------------------------------------------------
+    valid: List[Dict[str, Any]] = []
+    dropped = 0
+    for inst in instances:
+        if inst['vCPU'] and inst['memoryGiB'] and (inst['priceUSD_hourly'] > 0 or inst['commitments']):
+            valid.append(inst)
+        else:
+            dropped += 1
+
+    print(f"After filtering: {len(valid)} valid instances, {dropped} dropped.", flush=True)
+    return valid
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    azure_data = fetch_azure_data()
-    with open("data/azure.json", "w") as f:
-        json.dump(azure_data, f, indent=2)
+    os.makedirs("data/providers", exist_ok=True)
+    output_path = "data/providers/azure.raw.json"
+
+    print("=== Azure fetcher (Stage 3 — Reservation extension) ===", flush=True)
+
+    global_instances = fetch_azure_data()
+    china_instances = fetch_china_static()
+    all_instances = global_instances + china_instances
+
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(all_instances, f, indent=2)
+
+    vm_count = sum(1 for i in all_instances if i.get('type') == 'cloud-server')
+    with_commitments = sum(1 for i in all_instances if i.get('commitments'))
+
+    print(f"\nSaved {len(all_instances)} instances to {output_path}")
+    print(f"  - Global VM SKUs: {len(global_instances)}")
+    print(f"  - China instances (static): {len(china_instances)}")
+    print(f"  - Instances with commitments[]: {with_commitments}")
+    print("\nNote: Azure China pricing is approximate. "
+          "Verify with 21Vianet for actual pricing.")

--- a/scripts/utils/azure_regions.py
+++ b/scripts/utils/azure_regions.py
@@ -1,0 +1,308 @@
+"""
+Azure region to country mapping utilities.
+Maps Azure region codes to proper country names for flag display.
+"""
+
+# Comprehensive Azure region to country mapping
+AZURE_REGION_MAPPING = {
+    # United States
+    'eastus': 'United States',
+    'eastus2': 'United States', 
+    'southcentralus': 'United States',
+    'westus2': 'United States',
+    'westus3': 'United States',
+    'australiaeast': 'Australia',
+    'southeastasia': 'Singapore',
+    'northeurope': 'Ireland',
+    'swedencentral': 'Sweden',
+    'uksouth': 'United Kingdom',
+    'westeurope': 'Netherlands',
+    'centralus': 'United States',
+    'southafricanorth': 'South Africa',
+    'centralindia': 'India',
+    'eastasia': 'Hong Kong',
+    'japaneast': 'Japan',
+    'koreacentral': 'South Korea',
+    'canadacentral': 'Canada',
+    'francecentral': 'France',
+    'germanywestcentral': 'Germany',
+    'norwayeast': 'Norway',
+    'switzerlandnorth': 'Switzerland',
+    'uaenorth': 'United Arab Emirates',
+    'brazilsouth': 'Brazil',
+    'centraluseuap': 'United States',
+    'eastus2euap': 'United States',
+    'qatarcentral': 'Qatar',
+    'centralusstage': 'United States',
+    'eastusstage': 'United States',
+    'eastus2stage': 'United States',
+    'northcentralusstage': 'United States',
+    'southcentralusstage': 'United States',
+    'westusstage': 'United States',
+    'westus2stage': 'United States',
+    'asia': 'Singapore',  # Regional grouping
+    'asiapacific': 'Singapore',  # Regional grouping
+    'australia': 'Australia',  # Regional grouping
+    'brazil': 'Brazil',  # Regional grouping
+    'canada': 'Canada',  # Regional grouping
+    'europe': 'Ireland',  # Regional grouping - default to Ireland
+    'france': 'France',  # Regional grouping
+    'germany': 'Germany',  # Regional grouping
+    'global': 'Global',  # Global services
+    'india': 'India',  # Regional grouping
+    'japan': 'Japan',  # Regional grouping
+    'korea': 'South Korea',  # Regional grouping
+    'norway': 'Norway',  # Regional grouping
+    'southafrica': 'South Africa',  # Regional grouping
+    'switzerland': 'Switzerland',  # Regional grouping
+    'uae': 'United Arab Emirates',  # Regional grouping
+    'uk': 'United Kingdom',  # Regional grouping
+    'unitedstates': 'United States',  # Regional grouping
+    'unitedstateseuap': 'United States',  # Regional grouping
+    
+    # More specific regions
+    'australiacentral': 'Australia',
+    'australiacentral2': 'Australia',
+    'australiasoutheast': 'Australia',
+    'brazilsoutheast': 'Brazil',
+    'canadaeast': 'Canada',
+    'chinaeast': 'China',
+    'chinaeast2': 'China',
+    'chinanorth': 'China',
+    'chinanorth2': 'China',
+    'chinanorth3': 'China',
+    'eastusg': 'United States',  # US Government
+    'southcentralusg': 'United States',  # US Government
+    'westcentralus': 'United States',
+    'westus': 'United States',
+    'francecentral': 'France',
+    'francesouth': 'France',
+    'germanynorth': 'Germany',
+    'japanwest': 'Japan',
+    'jioindiacentral': 'India',
+    'jioindiawest': 'India',
+    'koreasouth': 'South Korea',
+    'northcentralus': 'United States',
+    'norwaywest': 'Norway',
+    'southafricawest': 'South Africa',
+    'southindia': 'India',
+    'switzerlandwest': 'Switzerland',
+    'uaecentral': 'United Arab Emirates',
+    'ukwest': 'United Kingdom',
+    'westindia': 'India',
+    'westus2': 'United States',
+    
+    # New regions and specific mappings from the data
+    'indonesiacentral': 'Indonesia',
+    'spaincentral': 'Spain',
+    'italynorth': 'Italy',
+    'israelnorth': 'Israel',
+    'israelnorthwest': 'Israel',
+    'mexicocentral': 'Mexico',
+    'polandcentral': 'Poland',
+    'taiwannorth': 'Taiwan',
+    'swedencentral': 'Sweden',
+    'denmarkeast': 'Denmark',
+    'finlandcentral': 'Finland',
+    'austriaeast': 'Austria',
+    'belgiumcentral': 'Belgium',
+    'chilecentral': 'Chile',
+    'colombiacentral': 'Colombia',
+    'malaysiasouth': 'Malaysia',
+    'newzealandnorth': 'New Zealand',
+    'saudi­arabiacentral': 'Saudi Arabia',
+    'saudiarabiacentral': 'Saudi Arabia',
+    'singaporecentral': 'Singapore',
+    'southkoreacentral': 'South Korea',
+    'southkorea­south': 'South Korea',
+    'southkoreasouth': 'South Korea',
+    'vietnamcentral': 'Vietnam',
+    'moldovacentral': 'Moldova',
+    'greececentral': 'Greece',
+    
+    # AT&T and other US regions that were missed
+    'atlanta1': 'United States',
+    'attatlanta1': 'United States',
+    'attdallas1': 'United States',
+    'attdetroit1': 'United States',
+    'attnewyork1': 'United States',
+    'attchicago1': 'United States',
+    'attlosangeles1': 'United States',
+    'attmiami1': 'United States',
+    'attseattle1': 'United States',
+    'attsilicon1': 'United States',
+    'attwashington1': 'United States',
+    
+    # Global and special regions
+    'global': 'Global',
+    'worldwide': 'Global',
+}
+
+def get_country_from_azure_region(region_code: str) -> str:
+    """
+    Map Azure region code to country name.
+    
+    Args:
+        region_code: Azure region code (e.g., 'westeurope', 'eastus')
+        
+    Returns:
+        Country name or 'Unknown' if not found
+    """
+    if not region_code:
+        return 'Unknown'
+    
+    # Convert to lowercase for consistent matching
+    region_lower = region_code.lower().strip()
+    
+    # Direct mapping lookup
+    if region_lower in AZURE_REGION_MAPPING:
+        return AZURE_REGION_MAPPING[region_lower]
+    
+    # Fallback patterns for unknown regions
+    region_patterns = {
+        'us': 'United States',
+        'europe': 'Europe',
+        'asia': 'Asia',
+        'australia': 'Australia',
+        'canada': 'Canada',
+        'brazil': 'Brazil',
+        'japan': 'Japan',
+        'korea': 'South Korea',
+        'india': 'India',
+        'china': 'China',
+        'uk': 'United Kingdom',
+        'france': 'France',
+        'germany': 'Germany',
+        'norway': 'Norway',
+        'sweden': 'Sweden',
+        'switzerland': 'Switzerland',
+        'africa': 'South Africa',
+        'uae': 'United Arab Emirates',
+        'israel': 'Israel',
+        'spain': 'Spain',
+        'italy': 'Italy',
+        'mexico': 'Mexico',
+        'poland': 'Poland',
+        'taiwan': 'Taiwan',
+        'denmark': 'Denmark',
+        'finland': 'Finland',
+        'austria': 'Austria',
+        'belgium': 'Belgium',
+        'chile': 'Chile',
+        'colombia': 'Colombia',
+        'malaysia': 'Malaysia',
+        'newzealand': 'New Zealand',
+        'singapore': 'Singapore',
+        'vietnam': 'Vietnam',
+        'moldova': 'Moldova',
+        'greece': 'Greece',
+        'indonesia': 'Indonesia',
+        'saudi': 'Saudi Arabia',
+    }
+    
+    # Try pattern matching
+    for pattern, country in region_patterns.items():
+        if pattern in region_lower:
+            return country
+    
+    # Last resort: return the region code capitalized
+    return region_code.title()
+
+def get_all_azure_countries() -> list[str]:
+    """Get all unique countries from Azure regions."""
+    return sorted(list(set(AZURE_REGION_MAPPING.values())))
+
+def get_regions_by_country(country: str) -> list[str]:
+    """Get all Azure regions for a specific country."""
+    return [region for region, mapped_country in AZURE_REGION_MAPPING.items() 
+            if mapped_country == country]
+
+# Country name to ISO code mapping for flags
+COUNTRY_TO_ISO_CODE = {
+    'Afghanistan': 'AF',
+    'Albania': 'AL',
+    'Algeria': 'DZ',
+    'Argentina': 'AR',
+    'Armenia': 'AM',
+    'Australia': 'AU',
+    'Austria': 'AT',
+    'Azerbaijan': 'AZ',
+    'Bangladesh': 'BD',
+    'Belarus': 'BY',
+    'Belgium': 'BE',
+    'Bosnia and Herzegovina': 'BA',
+    'Brazil': 'BR',
+    'Bulgaria': 'BG',
+    'Canada': 'CA',
+    'Chile': 'CL',
+    'China': 'CN',
+    'Colombia': 'CO',
+    'Croatia': 'HR',
+    'Czech Republic': 'CZ',
+    'Denmark': 'DK',
+    'Egypt': 'EG',
+    'Estonia': 'EE',
+    'Finland': 'FI',
+    'France': 'FR',
+    'Germany': 'DE',
+    'Greece': 'GR',
+    'Hong Kong': 'HK',
+    'Hungary': 'HU',
+    'Iceland': 'IS',
+    'India': 'IN',
+    'Indonesia': 'ID',
+    'Ireland': 'IE',
+    'Israel': 'IL',
+    'Italy': 'IT',
+    'Japan': 'JP',
+    'Kazakhstan': 'KZ',
+    'Latvia': 'LV',
+    'Lithuania': 'LT',
+    'Luxembourg': 'LU',
+    'Malaysia': 'MY',
+    'Mexico': 'MX',
+    'Moldova': 'MD',
+    'Netherlands': 'NL',
+    'New Zealand': 'NZ',
+    'Norway': 'NO',
+    'Poland': 'PL',
+    'Portugal': 'PT',
+    'Qatar': 'QA',
+    'Romania': 'RO',
+    'Russia': 'RU',
+    'Saudi Arabia': 'SA',
+    'Singapore': 'SG',
+    'Slovakia': 'SK',
+    'Slovenia': 'SI',
+    'South Africa': 'ZA',
+    'South Korea': 'KR',
+    'Spain': 'ES',
+    'Sweden': 'SE',
+    'Switzerland': 'CH',
+    'Taiwan': 'TW',
+    'Thailand': 'TH',
+    'Turkey': 'TR',
+    'Ukraine': 'UA',
+    'United Arab Emirates': 'AE',
+    'United Kingdom': 'GB',
+    'United States': 'US',
+    'Vietnam': 'VN',
+    # Add some fallbacks for regions/groupings
+    'Europe': 'EU',
+    'Asia': 'AS', 
+    'Global': 'GLOBAL',  # Special code for global services
+}
+
+def get_country_code(country_name: str) -> str:
+    """Get ISO country code for flag display."""
+    return COUNTRY_TO_ISO_CODE.get(country_name, 'GLOBAL')  # Special code as fallback
+
+def create_location_detail(azure_region: str, country: str) -> dict:
+    """Create locationDetail object compatible with frontend."""
+    return {
+        'code': azure_region,
+        'city': azure_region.replace('central', '').replace('north', '').replace('south', '').replace('east', '').replace('west', '').title(),
+        'country': country,
+        'countryCode': get_country_code(country),
+        'region': azure_region
+    }

--- a/scripts/utils/azure_services.py
+++ b/scripts/utils/azure_services.py
@@ -1,0 +1,323 @@
+"""
+Azure service categorization and mapping utilities.
+Maps Azure services to standardized categories for CloudPriceFinder.
+"""
+
+# Azure service name to category mapping
+AZURE_SERVICE_CATEGORIES = {
+    # SERVERS (Virtual Machines and Compute)
+    'Virtual Machines': 'servers',
+    'Azure Virtual Machines': 'servers',
+    'Virtual Machine Scale Sets': 'servers',
+    'Azure Dedicated Host': 'servers',
+    'Azure Spot Virtual Machines': 'servers',
+    'Container Instances': 'servers',
+    'Azure Container Registry': 'servers',
+    'Azure Kubernetes Service': 'servers',
+    'App Service': 'servers',
+    'Azure Functions': 'servers',
+    'Logic Apps': 'servers',
+    'Service Fabric': 'servers',
+    'Batch': 'servers',
+    'Azure VMware Solution': 'servers',
+    'Azure Arc': 'servers',
+    
+    # NETWORKING (Load Balancers and Network Services)
+    'Load Balancer': 'networking',
+    'Azure Load Balancer': 'networking',
+    'Application Gateway': 'networking',
+    'Azure Application Gateway': 'networking',
+    'Traffic Manager': 'networking',
+    'Azure Traffic Manager': 'networking',
+    'Front Door': 'networking',
+    'Azure Front Door': 'networking',
+    'Azure CDN': 'networking',
+    'Content Delivery Network': 'networking',
+    'Azure Firewall': 'networking',
+    'VPN Gateway': 'networking',
+    'Azure VPN Gateway': 'networking',
+    'ExpressRoute': 'networking',
+    'Azure ExpressRoute': 'networking',
+    'Azure DDoS Protection': 'networking',
+    'Azure Bastion': 'networking',
+    'Virtual Network': 'networking',
+    'Azure Virtual Network': 'networking',
+    'Azure DNS': 'networking',
+    'Private Link': 'networking',
+    'Azure Private Link': 'networking',
+    
+    # DATABASES (SQL and NoSQL databases)
+    'SQL Database': 'databases',
+    'Azure SQL Database': 'databases',
+    'SQL Managed Instance': 'databases',
+    'Azure SQL Managed Instance': 'databases',
+    'Azure Database for PostgreSQL': 'databases',
+    'Azure Database for MySQL': 'databases',
+    'Azure Database for MariaDB': 'databases',
+    'Azure Cosmos DB': 'databases',
+    'Cosmos DB': 'databases',
+    'Azure Synapse Analytics': 'analytics',
+    'SQL Data Warehouse': 'databases',
+    'Azure Data Factory': 'analytics',
+    'Azure Databricks': 'analytics',
+    'Azure Analysis Services': 'databases',
+    'Azure Data Lake Storage': 'storage',
+    'Azure Data Lake Analytics': 'analytics',
+    'Azure Search': 'databases',
+    'Azure Cognitive Search': 'databases',
+    'SQL Server Stretch Database': 'databases',
+    
+    # CACHE (Cache and In-Memory databases)
+    'Azure Cache for Redis': 'cache',
+    'Redis Cache': 'cache',
+    
+    # STORAGE (Object storage and file systems)
+    'Azure Table Storage': 'storage',
+    'Azure Blob Storage': 'storage', 
+    'Azure Files': 'storage',
+    'Azure Queue Storage': 'storage',
+    'Storage': 'storage',
+    'Azure Storage': 'storage',
+    'Backup': 'storage',
+    'Azure Backup': 'storage',
+    'Site Recovery': 'storage',
+    'Azure Site Recovery': 'storage',
+    
+    # STORAGE (Additional storage services that don't fit databases)
+    'Azure NetApp Files': 'storage',
+    'Azure HPC Cache': 'storage',
+    'Azure FXT Edge Filer': 'storage',
+    'StorSimple': 'storage',
+    
+    # AI/ML (Artificial Intelligence and Machine Learning)
+    'Cognitive Services': 'ai-ml',
+    'Azure Cognitive Services': 'ai-ml',
+    'Azure Machine Learning': 'ai-ml',
+    'Machine Learning': 'ai-ml',
+    'Azure Bot Service': 'ai-ml',
+    'Azure Form Recognizer': 'ai-ml',
+    'Azure Computer Vision': 'ai-ml',
+    'Azure Speech Services': 'ai-ml',
+    'Azure Language Understanding': 'ai-ml',
+    'Azure Translator': 'ai-ml',
+    
+    # ANALYTICS (Business Intelligence and Analytics)
+    'Azure Stream Analytics': 'analytics',
+    'Stream Analytics': 'analytics',
+    'Azure Event Hubs': 'analytics',
+    'Event Hubs': 'analytics',
+    'Azure Event Grid': 'analytics',
+    'Event Grid': 'analytics',
+    'Azure Service Bus': 'analytics',
+    'Service Bus': 'analytics',
+    'Azure IoT Hub': 'analytics',
+    'IoT Hub': 'analytics',
+    'Azure IoT Central': 'analytics',
+    'IoT Central': 'analytics',
+    'Azure Time Series Insights': 'analytics',
+    'Power BI': 'analytics',
+    'Power BI Embedded': 'analytics',
+    
+    # SECURITY (Security and Identity)
+    'Azure Active Directory': 'security',
+    'Active Directory': 'security',
+    'Azure Key Vault': 'security',
+    'Key Vault': 'security',
+    'Azure Security Center': 'security',
+    'Security Center': 'security',
+    'Azure Sentinel': 'security',
+    'Azure Information Protection': 'security',
+    'Azure Multi-Factor Authentication': 'security',
+    
+    # MONITORING (Monitoring and Management)
+    'Azure Monitor': 'monitoring',
+    'Monitor': 'monitoring',
+    'Application Insights': 'monitoring',
+    'Azure Application Insights': 'monitoring',
+    'Log Analytics': 'monitoring',
+    'Azure Log Analytics': 'monitoring',
+    'Azure Automation': 'monitoring',
+    'Automation': 'monitoring',
+    'Azure Policy': 'monitoring',
+    'Azure Resource Manager': 'monitoring',
+    
+    # INTEGRATION (Integration Services)
+    'Azure API Management': 'integration',
+    'API Management': 'integration',
+    'Azure Logic Apps': 'integration',
+    'Azure Service Fabric': 'integration',
+    'Azure Relay': 'integration',
+    'Azure Notification Hubs': 'integration',
+    
+    # MEDIA (Media and Content Delivery)
+    'Media Services': 'media',
+    'Azure Media Services': 'media',
+    'Azure Content Moderator': 'media',
+    'Azure Video Indexer': 'media',
+    
+    # DEVELOPMENT (Developer Tools)
+    'Azure DevOps': 'development',
+    'DevOps': 'development',
+    'Azure DevTest Labs': 'development',
+    'DevTest Labs': 'development',
+    'Azure Repos': 'development',
+    'Azure Pipelines': 'development',
+    'Azure Artifacts': 'development',
+    'Azure Test Plans': 'development',
+    
+    # MIGRATION (Migration Services)
+    'Azure Migrate': 'migration',
+    'Migrate': 'migration',
+    'Azure Database Migration Service': 'migration',
+    'Azure Import/Export': 'migration',
+    'Azure Data Box': 'migration',
+}
+
+def get_service_category(service_name: str) -> str:
+    """
+    Get the category for an Azure service name.
+    
+    Args:
+        service_name: Azure service name from the API
+        
+    Returns:
+        Category string (servers, loadbalancers, databases, etc.)
+    """
+    if not service_name:
+        return 'other'
+    
+    # Direct mapping lookup
+    if service_name in AZURE_SERVICE_CATEGORIES:
+        return AZURE_SERVICE_CATEGORIES[service_name]
+    
+    # Fallback pattern matching for partial matches
+    service_lower = service_name.lower()
+    
+    # Check for key terms in service names
+    if any(term in service_lower for term in ['virtual machine', 'vm', 'compute', 'container', 'app service', 'function']):
+        return 'servers'
+    elif any(term in service_lower for term in ['load balancer', 'application gateway', 'traffic manager', 'cdn', 'firewall', 'vpn', 'network', 'dns']):
+        return 'networking'
+    elif any(term in service_lower for term in ['redis cache', 'cache for redis']):
+        return 'cache'
+    elif any(term in service_lower for term in ['sql', 'database', 'cosmos', 'synapse']):
+        return 'databases'
+    elif any(term in service_lower for term in ['storage', 'blob', 'file', 'table', 'queue', 'backup']):
+        return 'storage'
+    elif any(term in service_lower for term in ['cognitive', 'machine learning', 'ml', 'ai', 'bot', 'speech', 'vision', 'form recognizer']):
+        return 'ai-ml'
+    elif any(term in service_lower for term in ['stream analytics', 'event hub', 'event grid', 'service bus', 'iot', 'power bi']):
+        return 'analytics'
+    elif any(term in service_lower for term in ['active directory', 'key vault', 'security', 'sentinel', 'authentication']):
+        return 'security'
+    elif any(term in service_lower for term in ['monitor', 'insights', 'log analytics', 'automation', 'policy']):
+        return 'monitoring'
+    elif any(term in service_lower for term in ['api management', 'logic apps', 'service fabric', 'relay', 'notification']):
+        return 'integration'
+    elif any(term in service_lower for term in ['media services', 'content moderator', 'video indexer']):
+        return 'media'
+    elif any(term in service_lower for term in ['devops', 'devtest', 'repos', 'pipelines', 'artifacts']):
+        return 'development'
+    elif any(term in service_lower for term in ['migrate', 'migration', 'import', 'export', 'data box']):
+        return 'migration'
+    else:
+        return 'other'
+
+def get_service_type_from_category(category: str) -> str:
+    """
+    Map category to CloudPriceFinder service type.
+    
+    Args:
+        category: Service category from get_service_category()
+        
+    Returns:
+        CloudPriceFinder service type
+    """
+    category_to_type = {
+        'servers': 'cloud-server',
+        'networking': 'cloud-loadbalancer',  # Keep as cloud-loadbalancer for compatibility
+        'databases': 'cloud-database',
+        'cache': 'cloud-cache',
+        'storage': 'cloud-storage',
+        'ai-ml': 'cloud-ai-ml',
+        'analytics': 'cloud-analytics',
+        'security': 'cloud-security',
+        'monitoring': 'cloud-monitoring',
+        'integration': 'cloud-integration',
+        'media': 'cloud-media',
+        'development': 'cloud-development',
+        'migration': 'cloud-migration',
+        'other': 'cloud-other'
+    }
+    return category_to_type.get(category, 'cloud-other')
+
+def is_virtual_machine_service(service_name: str, meter_name: str = '') -> bool:
+    """
+    Check if a service is specifically a Virtual Machine service.
+    
+    Args:
+        service_name: Azure service name
+        meter_name: Azure meter name
+        
+    Returns:
+        True if this is a VM service
+    """
+    vm_indicators = [
+        'Virtual Machines',
+        'Azure Virtual Machines', 
+        'Virtual Machine Scale Sets',
+        'Azure Dedicated Host',
+        'Azure Spot Virtual Machines'
+    ]
+    
+    if service_name in vm_indicators:
+        return True
+    
+    # Check meter name for VM indicators
+    if meter_name and any(term in meter_name.lower() for term in ['virtual machine', 'vm ', 'dedicated host']):
+        return True
+        
+    return False
+
+def is_dedicated_host_service(service_name: str, meter_name: str = '') -> bool:
+    """
+    Check if a service is specifically a Dedicated Host service.
+    
+    Args:
+        service_name: Azure service name
+        meter_name: Azure meter name
+        
+    Returns:
+        True if this is a dedicated host service
+    """
+    dedicated_indicators = [
+        'Azure Dedicated Host',
+        'Dedicated Host'
+    ]
+    
+    if service_name in dedicated_indicators:
+        return True
+    
+    # Check meter name for dedicated host indicators
+    if meter_name and any(term in meter_name.lower() for term in ['dedicated host', 'dedicated compute']):
+        return True
+        
+    return False
+
+def get_china_region_mapping() -> dict:
+    """
+    Get mapping for Azure China regions.
+    
+    Returns:
+        Dictionary mapping Azure China regions to countries
+    """
+    return {
+        'chinaeast': 'China',
+        'chinaeast2': 'China', 
+        'chinanorth': 'China',
+        'chinanorth2': 'China',
+        'chinanorth3': 'China',
+        'chinawest': 'China',
+        'chinawest2': 'China',
+        'china': 'China'
+    }


### PR DESCRIPTION
## Summary

- Rewrote `scripts/fetch_azure.py` from 17-line placeholder to full implementation (~600 lines) using the Azure Retail Prices API.
- Fetches both `Consumption` (on-demand) and `Reservation` (1yr/3yr) rows for Virtual Machines service only.
- Skips `DevTestConsumption`, `Spot`, `Low Priority`, `Windows`, and `SQL` pricing rows.
- Groups by `armSkuName` + `armRegionName`; collapses to per-SKU records using `eastus` as the canonical pricing reference region, so `savingsVsOnDemandPct` is internally consistent with the parent instance's `priceUSD_hourly`.
- Amortises Reservation total cost (e.g. $496 for 1yr) to effective hourly (e.g. $0.0566/hr = $496 / 8760 hrs).
- Sets `payment: 'all-upfront'` — Azure Retail Prices API only exposes the upfront-equivalent amortised price.
- Azure China regions: static 21Vianet fallback (live API requires separate access). Confirmed China rows present in output.
- Adds `regionPricing{}` dict following the AWS fetcher pattern (Stage 2) for the Stage 6 aggregator.
- Added `scripts/utils/azure_regions.py` and `scripts/utils/azure_services.py` (ported from Azure branch, salvaged per plan).
- Ticked Stage 3 Definition of Done checkboxes in `PROJECT_TODO.md`.

## Verification command output

```
$ python scripts/fetch_azure.py
=== Azure fetcher (Stage 3 - Reservation extension) ===
Fetching Consumption (on-demand) rows...
  Total Consumption records fetched: 357667
Fetching Reservation rows...
  Total Reservation records fetched: 156639
Consumption groups built: 70142
  Skipped - Windows/SQL: 44, DevTest: 0, no SKU: 2, no specs: 2853
Reservations merged: 117414 matched, 39206 unmatched/skipped, 19 Windows/SQL skipped.
Final unique SKU count (global): 1805
After filtering: 1752 valid instances, 53 dropped.
Note: Azure China pricing requires 21Vianet API access. Using static fallback.
Added 4 China instances (static fallback).

Saved 1756 instances to data/providers/azure.raw.json
  - Global VM SKUs: 1752
  - China instances (static): 4
  - Instances with commitments[]: 1441
```

Standard_D2s_v5 commitment verification:
```
  priceUSD_hourly: 0.096  (eastus Linux on-demand)
  1yr: effectiveHourly=0.056621, savings=41.0%  [PASS: in 20-65% range]
  3yr: effectiveHourly=0.035502, savings=63.0%  [PASS: in 20-65% range]
```

```
$ python scripts/utils/data_validator.py data/providers/azure.raw.json
OK: 1756/1756 instances validated successfully
```

## Definition of Done

- [x] No regression: total VM count >= previous run (1756 instances, vs 0 from placeholder)
- [x] PR opened: `v3/stage-3-azure-reservations`

## Caveats / Limitations

- **API fetch time**: The Azure Retail Prices API returns ~357K consumption records and ~157K reservation records for Virtual Machines across all regions/SKUs. Each page has 1000 records, requiring ~514 HTTP requests. Full run takes approximately 15-20 minutes. This is acceptable for a weekly CI cron job but slow for manual runs. Future optimization: cache pages to disk or add `--sku-filter` CLI flag for development.
- **China pricing**: Azure China (21Vianet) uses a separate restricted API. A static fallback with 4 representative SKUs is included. The `raw.note` field documents this.
- **Azure API `unitPrice` for Reservations**: The API returns the **total reservation cost** (e.g., $496 for 1yr) despite `unitOfMeasure` saying "1 Hour". The fetcher correctly divides by term hours (8760 or 26280) to get the amortised hourly rate.
- **Spot/Low Priority filtering**: Added explicit filter for `skuName` containing "Spot" or "Low Priority" to prevent artificially low prices from being used as the on-demand baseline.
- **Canonical region**: `eastus` is used as the canonical reference region for per-SKU price and commitment savings calculation. SKUs not available in eastus fall back to the first encountered region.

## Suggested next stage

Stage 4 (OCI fetcher verification and extension) can run in parallel with Stages 2/3/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)