### PR TITLE
fix: bypass Cloudflare Rocket Loader interference with Astro module p…

### DIFF
--- a/_headers
+++ b/_headers
@@ -31,3 +31,4 @@
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Cache-Control: no-transform

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,19 @@ import tailwindcss from '@tailwindcss/vite';
 
 const SITE_URL = 'https://cloudpricefinder.com';
 
+// Cloudflare Rocket Loader rewrites <script type="module"> tags, causing a
+// credentials mode mismatch with Astro's <link rel="modulepreload" crossorigin>
+// and wasting every preload. data-cfasync="false" opts the script out of
+// Rocket Loader processing entirely.
+function cfRocketLoaderBypass() {
+  return {
+    name: 'cf-rocket-loader-bypass',
+    transformIndexHtml(html) {
+      return html.replace(/<script type="module"/g, '<script type="module" data-cfasync="false"');
+    },
+  };
+}
+
 export default defineConfig({
   site: SITE_URL,
   integrations: [sitemap()],
@@ -12,6 +25,6 @@ export default defineConfig({
     inlineStylesheets: 'auto',
   },
   vite: {
-    plugins: [tailwindcss()],
+    plugins: [tailwindcss(), cfRocketLoaderBypass()],
   },
 });


### PR DESCRIPTION
…reloads

Rocket Loader rewrites <script type="module"> tags, breaking the credentials mode alignment with Astro's <link rel="modulepreload" crossorigin> and causing every preload to be silently discarded by the browser.

- Add cfRocketLoaderBypass Vite plugin to inject data-cfasync="false" on all module script tags at build time (official CF opt-out mechanism)
- Add Cache-Control: no-transform to _headers as belt-and-suspenders