### PR TITLE
feat(stage-f): CSV export + Print/PDF export

### DIFF
--- a/src/components/ComparisonTable.astro
+++ b/src/components/ComparisonTable.astro
@@ -11,16 +11,27 @@
       <div class="flex items-center space-x-4">
         <!-- Result count -->
         <div class="text-sm text-gray-500" id="result-count">Loading...</div>
-        <!-- Page size -->
-        <div class="flex items-center space-x-2">
-          <label for="page-size" class="text-sm text-gray-500">Show:</label>
-          <select id="page-size" class="text-sm border-gray-300 rounded-sm">
-            <option value="50">50</option>
-            <option value="100" selected>100</option>
-            <option value="200">200</option>
-            <option value="500">500</option>
-            <option value="all">All</option>
-          </select>
+        <!-- Page size + export -->
+        <div class="flex items-center space-x-3">
+          <div class="flex items-center space-x-2">
+            <label for="page-size" class="text-sm text-gray-500">Show:</label>
+            <select id="page-size" class="text-sm border-gray-300 rounded-sm">
+              <option value="50">50</option>
+              <option value="100" selected>100</option>
+              <option value="200">200</option>
+              <option value="500">500</option>
+              <option value="all">All</option>
+            </select>
+          </div>
+          <button id="export-csv-btn"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-40 disabled:cursor-not-allowed"
+            disabled title="Export visible results as CSV">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+            </svg>
+            Export CSV
+          </button>
         </div>
       </div>
     </div>
@@ -444,6 +455,7 @@
     }
 
     if (resultCount) resultCount.textContent = `${total.toLocaleString()} instances`;
+    if (exportCsvBtn) exportCsvBtn.disabled = total === 0;
 
     const totalPages = effectivePageSize > 0 ? Math.ceil(total / effectivePageSize) : 1;
     if (pageInfo) pageInfo.textContent = `Page ${currentPage} of ${Math.max(1, totalPages)}`;
@@ -890,6 +902,86 @@
     currentPage = 1;
     sortAndRender();
   });
+
+  // ---------------------------------------------------------------------------
+  // Export CSV (Stage F) — client-side only, no dependencies
+  // ---------------------------------------------------------------------------
+  const exportCsvBtn = document.getElementById('export-csv-btn') as HTMLButtonElement | null;
+
+  function exportCSV() {
+    const rows = filteredInstances;
+    if (!rows.length) return;
+
+    const headers = [
+      'Provider', 'Instance Type', 'Family', 'Architecture',
+      'vCPU', 'RAM (GiB)', 'GPU',
+      'On-Demand $/hr',
+      '1yr Best $/hr', '1yr Savings %',
+      '3yr Best $/hr', '3yr Savings %',
+      'Spot $/hr',
+      'Regions',
+    ];
+
+    function bestCommitment(inst: V3Instance, term: '1yr' | '3yr'): { price: string; savings: string } {
+      const matches = (inst.commitments ?? []).filter((c) => c.term === term);
+      if (!matches.length) return { price: '', savings: '' };
+      const best = matches.reduce((a, b) => a.effectiveHourlyUSD < b.effectiveHourlyUSD ? a : b);
+      return {
+        price: best.effectiveHourlyUSD.toFixed(6),
+        savings: best.savingsVsOnDemandPct.toFixed(2),
+      };
+    }
+
+    function csvCell(value: string | number | undefined | null): string {
+      const s = String(value ?? '');
+      // Wrap in quotes if it contains a comma, quote, or newline
+      if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+        return `"${s.replace(/"/g, '""')}"`;
+      }
+      return s;
+    }
+
+    const lines: string[] = [headers.map(csvCell).join(',')];
+
+    for (const inst of rows) {
+      const yr1 = bestCommitment(inst, '1yr');
+      const yr3 = bestCommitment(inst, '3yr');
+      const spotMatches = (inst.commitments ?? []).filter((c) => (c.term as string) === 'spot');
+      const spotPrice = spotMatches.length
+        ? String(Math.min(...spotMatches.map((c) => c.effectiveHourlyUSD)).toFixed(6))
+        : '';
+
+      lines.push([
+        csvCell(inst.provider),
+        csvCell(inst.instanceType),
+        csvCell(inst.family),
+        csvCell(inst.architecture ?? 'x86_64'),
+        csvCell(inst.vCPU),
+        csvCell(inst.memoryGiB),
+        csvCell(inst.gpu ? `${inst.gpu.count}x ${inst.gpu.type}` : ''),
+        csvCell(inst.priceUSD_hourly != null ? inst.priceUSD_hourly.toFixed(6) : ''),
+        csvCell(yr1.price),
+        csvCell(yr1.savings),
+        csvCell(yr3.price),
+        csvCell(yr3.savings),
+        csvCell(spotPrice),
+        csvCell((inst.regions ?? []).join('|')),
+      ].join(','));
+    }
+
+    const blob = new Blob([lines.join('\r\n')], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    const date = new Date().toISOString().slice(0, 10);
+    a.download = `cloudpricefinder-${date}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  exportCsvBtn?.addEventListener('click', exportCSV);
 
   // ---------------------------------------------------------------------------
   // Pagination controls

--- a/src/pages/compare.astro
+++ b/src/pages/compare.astro
@@ -9,12 +9,23 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <div class="max-w-full mx-auto px-4 sm:px-6 lg:px-8 xl:px-12 2xl:px-16 py-8 flex-1">
 
     <!-- Page header -->
-    <div class="mb-6">
-      <h1 class="text-3xl font-bold text-gray-900 mb-2">Side-by-Side Comparison</h1>
-      <p class="text-gray-600">
-        Compare up to 4 instances across providers. Use the search boxes to add instances, or
-        follow a <span class="font-mono text-sm bg-gray-100 px-1 rounded-sm">?items=aws:m7i.xlarge,azure:Standard_D4s_v5</span> deep-link.
-      </p>
+    <div class="mb-6 flex items-start justify-between gap-4">
+      <div>
+        <h1 class="text-3xl font-bold text-gray-900 mb-2">Side-by-Side Comparison</h1>
+        <p class="text-gray-600">
+          Compare up to 4 instances across providers. Use the search boxes to add instances, or
+          follow a <span class="font-mono text-sm bg-gray-100 px-1 rounded-sm">?items=aws:m7i.xlarge,azure:Standard_D4s_v5</span> deep-link.
+        </p>
+      </div>
+      <button id="print-btn"
+        class="no-print shrink-0 inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 hidden"
+        title="Print or save as PDF">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+        </svg>
+        Print / Save PDF
+      </button>
     </div>
 
     <!-- Instance picker -->
@@ -510,5 +521,88 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     }
 
     init();
+
+    // -------------------------------------------------------------------------
+    // Print button (Stage F) — show once table has content
+    // -------------------------------------------------------------------------
+    const printBtn = document.getElementById('print-btn') as HTMLButtonElement | null;
+    printBtn?.addEventListener('click', () => {
+      // Stamp current date for print footer
+      compareTableWrapper.setAttribute('data-date', new Date().toLocaleDateString());
+      window.print();
+    });
+
+    // Reveal print button when table is rendered
+    const tableObserver = new MutationObserver(() => {
+      if (!compareTableWrapper.classList.contains('hidden')) {
+        printBtn?.classList.remove('hidden');
+      } else {
+        printBtn?.classList.add('hidden');
+      }
+    });
+    tableObserver.observe(compareTableWrapper, { attributes: true, attributeFilter: ['class'] });
   </script>
+
+  <style>
+    @media print {
+      /* Hide everything except the comparison table */
+      .no-print,
+      header, footer, nav,
+      #picker-row,
+      #compare-error,
+      #compare-empty,
+      #compare-loading {
+        display: none !important;
+      }
+
+      body {
+        font-size: 11pt;
+        background: white;
+      }
+
+      /* Remove padding so table fills the page */
+      .max-w-full {
+        max-width: 100% !important;
+        padding: 0 !important;
+      }
+
+      /* Ensure table borders print */
+      #compare-table th,
+      #compare-table td {
+        border: 1px solid #d1d5db !important;
+        padding: 4pt 6pt !important;
+      }
+
+      /* Keep table on one page if possible */
+      #compare-table {
+        width: 100%;
+        page-break-inside: avoid;
+      }
+
+      /* Print-friendly header */
+      h1 {
+        font-size: 16pt;
+        margin-bottom: 8pt;
+      }
+
+      p {
+        display: none;
+      }
+
+      /* Remove toggle buttons from print */
+      .compare-term-btn {
+        display: none !important;
+      }
+
+      /* Add print timestamp footer */
+      #compare-table-wrapper::after {
+        content: "Exported from CloudPriceFinder (cloudpricefinder.com) — " attr(data-date);
+        display: block;
+        margin-top: 12pt;
+        font-size: 8pt;
+        color: #6b7280;
+        text-align: center;
+      }
+    }
+  </style>
 </BaseLayout>


### PR DESCRIPTION
## Summary

- **Export CSV** button in the main comparison table header exports all currently-filtered instances to a `.csv` file (client-side, native `Blob` + `createObjectURL` — zero new dependencies). Columns: provider, instance type, family, architecture, vCPU, RAM (GiB), GPU, on-demand $/hr, 1yr best $/hr, 1yr savings %, 3yr best $/hr, 3yr savings %, spot $/hr (empty until Stage B), regions (pipe-separated).
- Button is disabled until data loads and when the result set is empty.
- **Print / Save PDF** button on the compare page triggers `window.print()` with `@media print` styles that hide nav, footer, picker controls, and commitment toggle buttons, and format the compare table cleanly for paper/PDF output. The button only appears once the compare table has content.

## Test plan

- [ ] Load the main table, apply some filters, click **Export CSV** — verify a `.csv` file downloads with correct columns and data
- [ ] Load the main table with no results (filters that match nothing) — verify button is disabled
- [ ] Navigate to `/compare?items=aws:m7i.xlarge,azure:Standard_D4s_v5` — verify **Print / Save PDF** button appears
- [ ] Click Print — verify nav/footer/picker are hidden in the print preview and the table renders cleanly
- [ ] Type-check green ✅ · Build green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)